### PR TITLE
fix: make binary executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y graphviz
           sudo curl -o /usr/local/bin/plantuml.jar https://sourceforge.net/projects/plantuml/files/plantuml.jar/download
+          sudo chmod +x /usr/local/bin/plantuml.jar
       - name: Build Diagrams
         run: |
           bash build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Build Diagrams
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ find . -name "*.puml" -type f -exec cp --parents {} temp \;
 # Genera las imágenes PNG correspondientes a cada archivo .puml
 cd temp
 for file in $(find . -name "*.puml" -type f); do
-  plantuml -tpng $file
+  java -jar /usr/local/bin/plantuml.jar -tpng $file
 done
 
 # Copia las imágenes generadas a una carpeta del repositorio


### PR DESCRIPTION
## Summary

Error executing the binary, as it was not found. Here you can see the [traces](https://github.com/MundakaZgz/diagrams/actions/runs/4349210241/jobs/7598606594#step:5:7) on a previous run.

## Fix

- Make sure binary is executable after downloading.
- Change execution command into the `build.sh`
- Add manual execution capabilities to CI workflow for debugging